### PR TITLE
feat: do not expect blank lines between two curls

### DIFF
--- a/lua/utils.lua
+++ b/lua/utils.lua
@@ -18,6 +18,11 @@ function M.get_lines_until_empty_or_eof(line_number)
 		-- remove whitespace from the beginning of the line
 		line_text = line_text:gsub("^%s+", "")
 
+        -- Check new curl line
+	    if line_text:match("^curl") and line > line_number then
+            break
+        end
+
 		-- Check if the line is empty
 		if line_text == "" then
 			-- If empty, stop iterating


### PR DESCRIPTION
# Problem

Having two curl's with no blank line in between causes unexpected behaviour

The best case you get the answer of the N subsequent lines of curl one next to the other in the result buffer, but with some APIs the response isn't the expected (maybe something with the headers)

# Solution

Stop counting lines when line starts with 'curl'.